### PR TITLE
bugs fixed and proper jQuery 1.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,11 @@ Or clone from:
 	     });
         </script>
 
+Since jQuery 1.9, 'live' tipsy expects selector as live option, e.g:
+
+        $(document).tipsy({
+            live: '.live-tooltip'
+        });
+
 Please refer to the docs directory for more examples and documentation.
 

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -215,10 +215,20 @@
         if (!options.live) this.each(function() { get(this); });
 
         if (options.trigger != 'manual') {
-            var binder   = options.live ? 'on' : 'bind',
-                eventIn  = options.trigger == 'hover' ? 'mouseenter mouseover' : 'focus',
+            var eventIn  = options.trigger == 'hover' ? 'mouseenter mouseover' : 'focus',
                 eventOut = options.trigger == 'hover' ? 'mouseleave mouseout' : 'blur';
-            this[binder](eventIn, enter)[binder](eventOut, leave);
+
+            if (options.live && options.live !== true) {
+                $(this).on(eventIn, options.live, enter);
+                $(this).on(eventOut, options.live, leave);
+            } else {
+                if (options.live && !$.live) {
+                    //live === true and using jQuery >= 1.9
+                    throw "Since jQuery 1.9, pass selector as live argument. eg. $(document).tipsy({live: 'a.live'});";
+                }
+                var binder = options.live ? 'live' : 'bind';
+                this[binder](eventIn, enter)[binder](eventOut, leave);
+            }
         }
 
         return this;


### PR DESCRIPTION
I made 
- code lint (semicolons etc.)
- remove duplicate autoBounds method
- fix merge conflict, causing broken js 
- fixed theme support - if no theme given, behave like old version and add simple tipsy class 
- extend live option to work with jQury 1.9, it support selector now
