### PR TITLE
IE8 does not have HTMElement

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -16,6 +16,15 @@
         return false;
     }
 
+	// Returns true if it is a DOM element
+	// http://stackoverflow.com/a/384380/999
+	function isElement(o){
+		return (
+			typeof HTMLElement === "object" ? o instanceof HTMLElement : //DOM2
+			o && typeof o === "object" && o.nodeType === 1 && typeof o.nodeName==="string"
+		);	
+	}
+
     var tipsyIDcounter = 0;
     function tipsyID() {
         return "tipsyuid" + (tipsyIDcounter++);
@@ -34,7 +43,7 @@
                 return;
             }
 
-            if (this.$element instanceof HTMLElement && !this.$element.is(':visible')) { 
+            if (isElement(this.$element) && !this.$element.is(':visible')) { 
                 return; 
             }
             


### PR DESCRIPTION
I added a little fix to get Tipsy to work with IE8. Threw error messages before and did not show tooltips.
