### PR TITLE
Fix the width of the bubble tip

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -104,6 +104,7 @@
 
                 $tip.css(tp).addClass('tipsy-' + gravity + this.options.theme);
                 $tip.find('.tipsy-arrow' + this.options.theme)[0].className = 'tipsy-arrow' + this.options.theme + ' tipsy-arrow-' + gravity.charAt(0) + this.options.theme;
+                $tip.css({width: (actualWidth - 10) + 'px'});
 
                 if (this.options.fade) {
                     if(this.options.shadow)


### PR DESCRIPTION
If you define a tooltip and then resize the window the tooltip won't work as expected.

Sample width no fixed size:
![no_fixed_width](https://f.cloud.github.com/assets/5265188/1109324/2930aa48-197e-11e3-8bed-6584fd1b664c.png)

Same width fixed size:
![fixed_width](https://f.cloud.github.com/assets/5265188/1109325/29518146-197e-11e3-83b1-9efab096271f.png)

Maybe there is a lovely way to solve it but this one was easy.
