### PR TITLE
Bugfixes for remnant tips

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -209,7 +209,7 @@
             } else {
                 tipsy.fixTitle();
                 setTimeout(function() {
-                    if (tipsy.hoverState == 'in' && isElementInDOM(tipsy.$element)) {
+                    if (tipsy.hoverState == 'in') {
                         tipsy.show();
                     }
                 }, options.delayIn);


### PR DESCRIPTION
This basically fixes the `$.fn.tipsy.revalidate()` function introduced in https://github.com/jaz303/tipsy/commit/8cd3dbc6e4814507a444afe847fec13c832c47bf that allows to programatically remove any remnant/obsolete tips from the DOM.
