### PR TITLE
Remove recursive width diminution

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -111,7 +111,7 @@
 
                 $tip.css(tp).addClass('tipsy-' + gravity + this.options.theme);
                 $tip.find('.tipsy-arrow' + this.options.theme)[0].className = 'tipsy-arrow' + this.options.theme + ' tipsy-arrow-' + gravity.charAt(0) + this.options.theme;
-                $tip.css({width: (actualWidth - 10) + 'px'});
+                $tip.css({width: actualWidth + 'px'});
 
                 if (this.options.fade) {
                     if (this.options.shadow) {


### PR DESCRIPTION
Every time a tipsy appeared, it was 20 px less wider.
I think this line creates a recursive diminution of the tipsy width.
By not substracting 10px, the bug disappears and the tipsy looks perfectly normal (not to wide).