### PR TITLE
Fixed tooltip sizes being 1px too small

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -56,7 +56,14 @@
                 }
 
                 $tip.detach()
-                    .css({top: 0, left: 0, visibility: 'hidden', display: 'block'})
+                    .css({
+                        top: 0,
+                        left: 0,
+                        width: '',
+                        height: '',
+                        visibility: 'hidden',
+                        display: 'block'
+                    })
                     .prependTo(this.options.prependTo)
                     .data('tipsy-pointee', this.$element[0]);
 

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -79,8 +79,9 @@
                     }
                 }
 
-                var actualWidth = $tip[0].offsetWidth,
-                    actualHeight = $tip[0].offsetHeight,
+                var bbox = $tip[0].getBoundingClientRect(),
+                    actualWidth = Math.ceil(bbox.width),
+                    actualHeight = Math.ceil(bbox.height),
                     gravity = maybeCall(this.options.gravity, this.$element[0]);
 
                 var tp;

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -309,6 +309,11 @@
             if (!pointee || !isElementInDOM(pointee)) {
                 $(this).remove();
             }
+
+            var tip = $.data(pointee, 'tipsy');
+            if (tip) {
+                tip.show();
+            }
         });
     };
 

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -304,6 +304,10 @@
         });
     };
 
+    $.fn.tipsy.clear = function() {
+        $('.tipsy').remove();
+    };
+
     $.fn.tipsy.enable = function() {
         $.fn.tipsy.enabled = true;
     };


### PR DESCRIPTION
This condition will occur if the actual content width isn't a whole number; `offsetWidth`/`offsetHeight` would floor the value resulting in the content wrapping when it shouldn't.

Also added a helper function for clearing all open tooltips.